### PR TITLE
Add Cloud Agent dev environment for WordPress + Elementor

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,19 @@
+{
+  "name": "Flexible Editor Panel (WordPress + Elementor)",
+  "user": "ubuntu",
+  "install": "./.cursor/install.sh",
+  "start": "./.cursor/start.sh",
+  "terminals": [
+    {
+      "name": "wordpress",
+      "command": "php -S 0.0.0.0:8080 -t \"$HOME/wordpress\" \"$HOME/wordpress/router.php\"",
+      "description": "WordPress dev server (http://localhost:8080). Admin: /wp-admin (admin / admin). The plugin is symlinked into wp-content/plugins/flexible-elementor-panel and activated alongside Elementor."
+    }
+  ],
+  "ports": [
+    {
+      "name": "wordpress",
+      "port": 8080
+    }
+  ]
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+#
+# Idempotent setup for a local WordPress + Elementor site that hosts this
+# plugin. Installs system packages, downloads WordPress core, provisions a
+# database, installs & activates Elementor, and symlinks + activates this
+# plugin. Safe to run repeatedly.
+set -euo pipefail
+
+# Resolve the repository root (this script lives in <repo>/.cursor/).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+WP_DIR="${WP_DIR:-$HOME/wordpress}"
+WP_PORT="${WP_PORT:-8080}"
+WP_URL="http://localhost:${WP_PORT}"
+PLUGIN_SLUG="flexible-elementor-panel"
+
+DB_NAME="wordpress"
+DB_USER="wp"
+DB_PASS="wp"
+
+echo "==> Installing system packages (php, mariadb, tools)"
+export DEBIAN_FRONTEND=noninteractive
+sudo apt-get update -y
+sudo apt-get install -y --no-install-recommends \
+  php-cli php-mysql php-gd php-curl php-mbstring php-xml php-zip php-intl php-bcmath php-imagick \
+  mariadb-server mariadb-client curl less
+
+if ! command -v wp >/dev/null 2>&1; then
+  echo "==> Installing WP-CLI"
+  curl -sSL -o /tmp/wp-cli.phar https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar
+  chmod +x /tmp/wp-cli.phar
+  sudo mv /tmp/wp-cli.phar /usr/local/bin/wp
+fi
+
+echo "==> Starting MariaDB (for setup)"
+sudo service mariadb start
+for _ in $(seq 1 30); do sudo mysqladmin ping >/dev/null 2>&1 && break; sleep 1; done
+
+echo "==> Ensuring database and user exist"
+sudo mysql -e "CREATE DATABASE IF NOT EXISTS ${DB_NAME} CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+CREATE USER IF NOT EXISTS '${DB_USER}'@'localhost' IDENTIFIED BY '${DB_PASS}';
+GRANT ALL PRIVILEGES ON ${DB_NAME}.* TO '${DB_USER}'@'localhost';
+FLUSH PRIVILEGES;"
+
+echo "==> Preparing WordPress at ${WP_DIR}"
+mkdir -p "$WP_DIR"
+cd "$WP_DIR"
+
+if [ ! -f "$WP_DIR/wp-load.php" ]; then
+  wp core download --allow-root
+fi
+
+if [ ! -f "$WP_DIR/wp-config.php" ]; then
+  wp config create --dbname="$DB_NAME" --dbuser="$DB_USER" --dbpass="$DB_PASS" \
+    --dbhost=127.0.0.1 --skip-check --allow-root
+  wp config set WP_DEBUG true --raw --type=constant --allow-root
+  wp config set WP_DEBUG_LOG true --raw --type=constant --allow-root
+  wp config set WP_DEBUG_DISPLAY false --raw --type=constant --allow-root
+fi
+
+if ! wp core is-installed --allow-root 2>/dev/null; then
+  wp core install --url="$WP_URL" --title="FEP Dev Site" \
+    --admin_user=admin --admin_password=admin --admin_email=admin@example.com \
+    --skip-email --allow-root
+fi
+
+wp option update siteurl "$WP_URL" --allow-root
+wp option update home "$WP_URL" --allow-root
+
+echo "==> Installing/activating Elementor"
+if ! wp plugin is-installed elementor --allow-root; then
+  wp plugin install elementor --allow-root
+fi
+wp plugin activate elementor --allow-root
+
+echo "==> Linking and activating this plugin (${PLUGIN_SLUG})"
+ln -sfn "$REPO_DIR" "$WP_DIR/wp-content/plugins/$PLUGIN_SLUG"
+wp plugin activate "$PLUGIN_SLUG" --allow-root
+
+echo "==> Writing PHP built-in server router"
+cat > "$WP_DIR/router.php" <<'PHP'
+<?php
+// Router for PHP built-in server to serve WordPress (dev only).
+// Uses the lexical request path (not realpath) so files under symlinked
+// plugins in wp-content/plugins are served even when the symlink target
+// lives outside the docroot.
+$root = __DIR__;
+$uri  = urldecode(parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH));
+if (strpos($uri, '..') === false) {
+    $path = $root . $uri;
+    if ($uri !== '/' && is_file($path)) {
+        return false;
+    }
+    if ($uri !== '/' && is_dir($path) && is_file(rtrim($path, '/') . '/index.php')) {
+        require rtrim($path, '/') . '/index.php';
+        return true;
+    }
+}
+require $root . '/index.php';
+PHP
+
+echo "==> Ensuring an Elementor-enabled demo page exists"
+if ! wp post list --post_type=page --field=ID --allow-root 2>/dev/null | grep -q .; then
+  PAGE_ID="$(wp post create --post_type=page --post_title="FEP Test Page" \
+    --post_status=publish --porcelain --allow-root)"
+  wp post meta update "$PAGE_ID" _elementor_edit_mode builder --allow-root
+  wp post meta update "$PAGE_ID" _elementor_template_type wp-page --allow-root
+fi
+
+echo "==> Setup complete. Installed plugins:"
+wp plugin list --allow-root

--- a/.cursor/start.sh
+++ b/.cursor/start.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+#
+# Per-boot startup: bring up the MariaDB daemon that WordPress needs.
+# Idempotent — safe to run when MariaDB is already running. The WordPress
+# dev server itself runs in the "wordpress" terminal (see environment.json).
+set -euo pipefail
+
+echo "==> Starting MariaDB"
+sudo service mariadb start || true
+
+echo "==> Waiting for MariaDB to accept connections"
+for _ in $(seq 1 30); do
+  if sudo mysqladmin ping >/dev/null 2>&1; then
+    echo "MariaDB is ready"
+    exit 0
+  fi
+  sleep 1
+done
+
+echo "MariaDB did not become ready in time" >&2
+exit 1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This repository is a WordPress plugin (**Flexible Editor Panel for Elementor**), an add-on for the Elementor page builder. It has no standalone build tooling, so "running the app" means standing up WordPress + Elementor with this plugin installed. This PR adds a reproducible Cloud Agent development environment that does exactly that.

## What's added (`.cursor/`)

- `environment.json` — repo-managed environment: default image, `install`/`start` scripts, a `wordpress` terminal running the PHP dev server on port `8080`, and an exposed port.
- `install.sh` — idempotent setup: installs PHP 8.3 + extensions, MariaDB, and WP-CLI; downloads WordPress core; provisions the `wordpress` database; installs & activates Elementor; symlinks this repo into `wp-content/plugins/flexible-elementor-panel` and activates it; writes a router for the PHP built-in server; and creates an Elementor-enabled demo page.
- `start.sh` — per-boot startup that brings up MariaDB and waits for readiness.

The plugin is symlinked (not copied) into `wp-content/plugins`, so edits in the repo are reflected live. The custom router serves symlinked plugin assets correctly.

## How to use

Once the environment is up, WordPress is at `http://localhost:8080` and wp-admin login is `admin` / `admin`. Open the Elementor editor to see the plugin's flexible-panel controls.

## Validation

| Check | Result |
| --- | --- |
| `install.sh` end-to-end | WordPress 7.1, Elementor 4.2.3, FEP 2.6.1 all active |
| `install.sh` idempotence | Passed (re-run reports "already active/unchanged") |
| `start.sh` | MariaDB starts and accepts connections |
| WordPress front page / wp-admin | HTTP 200 |
| FEP admin settings page | Renders (`admin.php?page=fep-options`) |
| Elementor editor loads with FEP | FEP header buttons (Collapse Vertical / Reset Panel / Exit), "Collapse categories" toggle, scripts & styles all present |
| PHP debug log | No warnings/errors during editor load |

Evidence was captured via a headless Chrome walkthrough (login → FEP settings → Elementor editor → toggling the "Collapse categories" feature).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-44496423-9227-46ab-82ed-a8d134090ce2?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-44496423-9227-46ab-82ed-a8d134090ce2&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

